### PR TITLE
fix: update result extraction in generate_docs.py for tensor compatibility

### DIFF
--- a/generate_docs.py
+++ b/generate_docs.py
@@ -389,8 +389,8 @@ source = device.add_source(
 results = device.solve(source) # SolverResults object
 
 # Extract the results
-print(f"Transmission: {results.transmission * 100:.2f}%")
-print(f"Reflection: {results.reflection * 100:.2f}%")
+print(f"Transmission: {results.transmission.item() * 100:.2f}%")
+print(f"Reflection: {results.reflection.item() * 100:.2f}%")
                 
 print("Phase of the transmission field x-component: ", torch.angle(results.transmission_field.x))
 print("Phase of the reflection field x-component: ", torch.angle(results.reflection_field.x))
@@ -1161,7 +1161,7 @@ sources = [
 results = solver.solve(sources)
 
 # Access results
-print(f"Transmission for all angles: {results.transmission[:, 0]}")
+print(f"Transmission for all angles: {results.transmission[:, 0].item()}")
 best_idx = results.find_optimal_source('max_transmission')
 print(f"Best angle: {sources[best_idx]['theta'] * 180/np.pi:.1f}°")
 ```


### PR DESCRIPTION
This pull request makes minor corrections to how transmission and reflection values are printed in the documentation generation scripts. The changes ensure that scalar values are properly extracted from tensors before formatting, which prevents potential formatting errors.

- Documentation output fixes:
  * Updated the print statements in `generate_docs.py` to use `.item()` when printing scalar values for transmission and reflection, ensuring compatibility with PyTorch tensor outputs. [[1]](diffhunk://#diff-c81260f9cbf9e608b1ffb1ff03a4c09259ee6cb452c492cc234816b6574ea71aL392-R393) [[2]](diffhunk://#diff-c81260f9cbf9e608b1ffb1ff03a4c09259ee6cb452c492cc234816b6574ea71aL1164-R1164)