### PR TITLE
docs: add docstrings of FFF features

### DIFF
--- a/src/torchrdit/builder.py
+++ b/src/torchrdit/builder.py
@@ -626,7 +626,15 @@ class SolverBuilder:
         """Configure tangent vector field generation behaviour.
 
         Args:
-            scheme: Tangent field scheme (e.g., ``'POL'``, ``'NORMAL'``).
+            scheme: Tangent field scheme used by Fast Fourier Factorization. Supported
+                values mirror :func:`torchrdit.vector.compute_tangent_field`:
+
+                * ``"POL"`` – polarization-preserving tangents normalized by the global maximum.
+                * ``"NORMAL"`` – per-pixel unit tangents for geometry-driven factorization.
+                * ``"JONES"`` – convert refined tangents into Jones vectors after the solve.
+                * ``"JONES_DIRECT"`` – execute the Newton solve directly in Jones space.
+
+                Defaults to the builder's current choice (``"POL"`` for new instances).
             fourier_weight: Weight for the Fourier-domain loss term.
             smoothness_weight: Weight for the spatial smoothness penalty.
             steps: Number of Newton iterations for tangent field refinement.

--- a/src/torchrdit/solver.py
+++ b/src/torchrdit/solver.py
@@ -574,8 +574,15 @@ def create_solver(
                     but adds computational overhead.
 
         fff_vector_scheme (str): Tangent vector field scheme to use when generating
-                Fourier-factorization normals. Options include ``'POL'``, ``'NORMAL'``,
-                ``'JONES'``, and ``'JONES_DIRECT'``. Default is ``'POL'``.
+                Fourier-factorization normals. Choose among:
+
+                * ``'POL'`` – polarization-preserving tangents normalized by the global maximum.
+                * ``'NORMAL'`` – per-pixel unit tangents for geometry-driven factorization.
+                * ``'JONES'`` – convert refined tangents into Jones vectors after the solve.
+                * ``'JONES_DIRECT'`` – run the Newton refinement directly in Jones space
+                  (fmmax/S4 style).
+
+                Default is ``'POL'``.
         fff_fourier_weight (float): Weight applied to the Fourier-domain loss
                 during tangent field refinement. Default is ``1e-2``.
         fff_smoothness_weight (float): Weight applied to the smoothness loss

--- a/src/torchrdit/vector.py
+++ b/src/torchrdit/vector.py
@@ -807,7 +807,38 @@ class TangentFieldGenerator:
         smoothness_loss_weight: float | None = None,
         steps: int | None = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Compute tangent fields for the requested scheme."""
+        """Compute tangent fields for the requested scheme.
+
+        Args:
+            mask (torch.Tensor): Pattern mask whose gradient informs the tangent solve.
+                The tensor must be two-dimensional and match ``XO``/``YO``.
+            XO (torch.Tensor): X-coordinate grid aligned with ``mask``.
+            YO (torch.Tensor): Y-coordinate grid aligned with ``mask``.
+            scheme (str): Name of the Fast Fourier Factorization tangent scheme. Supported
+                values are:
+
+                * ``"POL"`` – polarization-preserving tangents scaled by the global
+                  maximum magnitude. Use this when downstream code expects the original
+                  Newton update with only global normalization.
+                * ``"NORMAL"`` – elementwise unit vectors obtained by normalizing each
+                  pixel independently. This is appropriate when the FFF backend assumes
+                  pointwise unit tangents.
+                * ``"JONES"`` – converts the refined tangents into Jones vectors after
+                  the Newton solve, mirroring the TE/TM decomposition used in S4.
+                * ``"JONES_DIRECT"`` – runs the Newton solve directly in Jones space,
+                  matching fmmax/S4 style formulations where the optimizer works on the
+                  Jones representation from the outset.
+            fourier_loss_weight (float | None): Optional override for the Fourier-domain
+                regularization weight. Defaults to the value configured on construction.
+            smoothness_loss_weight (float | None): Optional override for the spatial
+                smoothness regularizer. Defaults to the construction-time value.
+            steps (int | None): Number of Newton iterations to execute. Falls back to the
+                default configured for the generator when ``None``.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: Tangent field components ``(tx, ty)``
+            corresponding to the requested scheme.
+        """
         # `_calculate_vector_field` in `solver.py` squeezes the mask the solver stores
         # (possibly batched as `(N, H, W)` for dispersive stacks or vectorized inverse-
         # design loops) and feeds each slice into this method, which always expects a
@@ -857,7 +888,14 @@ class TangentFieldGenerator:
         smoothness_loss_weight: float,
         steps: int,
     ) -> Dict[str, Callable[[torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]]:
-        """Return scheme-specific callables."""
+        """Return scheme-specific callables.
+
+        The returned dictionary maps the canonical scheme name (``POL``, ``NORMAL``,
+        ``JONES``, ``JONES_DIRECT``) to a callable that executes the Newton solve and
+        any necessary post-processing for that representation. Each callable produces
+        a tuple ``(tx, ty)`` consistent with the description given in
+        :meth:`compute`.
+        """
         def _pol(arr: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
             field = self._compute_field(
                 arr,
@@ -1075,7 +1113,29 @@ def compute_tangent_field(
     smoothness_loss_weight: float = 1e-3,
     steps: int = 1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Compute tangent fields via ``TangentFieldGenerator``."""
+    """Compute tangent fields via ``TangentFieldGenerator``.
+
+    Args:
+        mask (torch.Tensor): Two-dimensional mask describing the patterned layer.
+        XO (torch.Tensor): X-coordinate grid with the same shape as ``mask``.
+        YO (torch.Tensor): Y-coordinate grid with the same shape as ``mask``.
+        lattice_t1 (torch.Tensor): First lattice vector in real space.
+        lattice_t2 (torch.Tensor): Second lattice vector in real space.
+        kdim (Tuple[int, int]): Number of Fourier harmonics along each axis.
+        scheme (str): Tangent vector scheme used for Fast Fourier Factorization.
+
+            * ``"POL"`` – global-magnitude normalized polarization vectors.
+            * ``"NORMAL"`` – per-pixel unit tangents suitable for geometric FFF models.
+            * ``"JONES"`` – tangents converted to Jones vectors after refinement.
+            * ``"JONES_DIRECT"`` – Newton refinement performed directly in Jones space.
+
+        fourier_loss_weight (float): Fourier-domain regularization weight.
+        smoothness_loss_weight (float): Spatial smoothness penalty weight.
+        steps (int): Number of Newton iterations to run.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: Tangent field components ``(tx, ty)``.
+    """
     generator = TangentFieldGenerator(
         lattice_t1=lattice_t1,
         lattice_t2=lattice_t2,


### PR DESCRIPTION
This pull request improves the clarity and usability of the tangent field generation and solver APIs by expanding and standardizing documentation for the available tangent vector schemes used in Fast Fourier Factorization (FFF). The changes ensure that users and developers can easily understand the behavior and options for tangent field computation throughout the codebase.

Documentation and API clarity improvements:

* Expanded docstrings for the `scheme` argument in `with_fff_vector_options` (`src/torchrdit/builder.py`) and `fff_vector_scheme` in `create_solver` (`src/torchrdit/solver.py`), detailing the four supported tangent schemes and their intended use cases. [[1]](diffhunk://#diff-822914293d8d962aac2a515ab5b0d6c706ffd8d95e118aa8c04909d33e76345bL629-R637) [[2]](diffhunk://#diff-fa5deed1bddfdf6a0e03a91425900198dfb812a2a96f6881dfa1216fff13a9dfL577-R585)
* Added comprehensive argument and return value documentation to `compute` and `compute_tangent_field` in `src/torchrdit/vector.py`, clarifying the behavior of each tangent scheme and the expected tensor shapes. [[1]](diffhunk://#diff-14f9ef0d08a9749ace940e2836c813e9b14d4d2d58103005419bd0ead3a4ae86L810-R841) [[2]](diffhunk://#diff-14f9ef0d08a9749ace940e2836c813e9b14d4d2d58103005419bd0ead3a4ae86L1078-R1138)
* Updated the internal `_scheme_dispatch` method documentation in `src/torchrdit/vector.py` to describe how scheme-specific callables are mapped and what output they produce.