### PR TITLE
fix(solver): correct FFF projection block ordering for Moharam field convention

### DIFF
--- a/src/torchrdit/__init__.py
+++ b/src/torchrdit/__init__.py
@@ -29,7 +29,7 @@ Key modules:
 
 """
 
-__version__ = "0.1.29"
+__version__ = "0.1.30"
 
 # Import core functionality
 from .gds import mask_to_gds, gds_to_mask, load_gds_vertices

--- a/src/torchrdit/solver.py
+++ b/src/torchrdit/solver.py
@@ -1550,14 +1550,19 @@ class FourierBaseSolver(Cell3D, SolverSubjectMixin):
                     p_yy = p_yy.unsqueeze(0).expand(n_sources, -1, -1, -1)
                     p_xx = p_xx.unsqueeze(0).expand(n_sources, -1, -1, -1)
 
+                # Liu 2012 eq.51 defines E2 in the [-Ey, Ex] field ordering,
+                # but torchrdit's Q matrix uses the [Ex, Ey] ordering.  The
+                # coordinate transformation swaps the diagonal P blocks:
+                #   Q[0:n, n:] uses p_xx (not p_yy)
+                #   Q[n:, 0:n] uses p_yy (not p_xx)
                 q_mat_i = blockmat2x2(
                     [
                         [
                             mat_kx_diag @ solve_tur_mky - delta_toeplitz_er @ p_xy,
-                            toeplitz_er - mat_kx_diag @ solve_tur_mkx - delta_toeplitz_er @ p_yy,
+                            toeplitz_er - mat_kx_diag @ solve_tur_mkx - delta_toeplitz_er @ p_xx,
                         ],
                         [
-                            mat_ky_diag @ solve_tur_mky - toeplitz_er + delta_toeplitz_er @ p_xx,
+                            mat_ky_diag @ solve_tur_mky - toeplitz_er + delta_toeplitz_er @ p_yy,
                             delta_toeplitz_er @ p_yx - mat_ky_diag @ solve_tur_mkx,
                         ],
                     ]


### PR DESCRIPTION
## Summary

Fix the FFF (Fast Fourier Factorization) tangent-field projection block ordering in the Q-matrix construction. The P_tangent diagonal blocks were swapped, causing FFF to modify the wrong polarisation.

## Root cause

Liu & Fan 2012 eq.51 defines the transverse permittivity E2 in `[-Ey, Ex]^T` field ordering. torchrdit's Moharam Q matrix uses `[Ex, Ey]^T` ordering (consistent with Li 1997). The coordinate transformation between these orderings swaps the diagonal blocks of P_tangent, but the code applied P directly without this swap.

**Before fix**: FFF modified TE (shouldn't change) and left TM unchanged (should improve).
**After fix**: FFF correctly leaves TE unchanged and improves TM convergence.

## Change

Swap `p_xx ↔ p_yy` in Q's diagonal blocks (solver.py, 2 lines):

```python
# Before:
Q[0:n, n:] = eps - Kx² - delta @ p_yy
Q[n:, 0:n] = Ky² - eps + delta @ p_xx

# After:
Q[0:n, n:] = eps - Kx² - delta @ p_xx
Q[n:, 0:n] = Ky² - eps + delta @ p_yy
```

## Validation

**Metal grating (1D, ε = -7.632+0.731j) — TM now matches fmmax:**

| harmonics | no_FFF | torchrdit FFF | fmmax POL |
|-----------|:------:|:------------:|:---------:|
| 3×3       | 0.616  | **0.697**    | 0.695     |
| 5×5       | 0.702  | **0.840**    | 0.839     |
| 7×7       | 0.715  | **0.830**    | 0.829     |
| 11×11     | 0.667  | **0.833**    | 0.823     |

**TE correctly unchanged**: diff < 1e-13 at all harmonic counts.

**Dielectric circle (ε=4 on glass)**: FFF accelerates R convergence toward final value.

## Test plan

- [x] Unit tests: 498 passed
- [x] 1D metal grating: TM convergence matches fmmax POL (diff < 0.01)
- [x] 1D metal grating: TE unchanged by FFF (diff < 1e-13)
- [x] Dielectric circle: FFF accelerates convergence
- [x] Cross-referenced with Liu 2012 eq.15,43,50,51 and Li 1997 eq.32-34
- [ ] CI: lint + pytest across Python 3.10–3.13

Closes #59